### PR TITLE
modified:   meta/makefile.pret

### DIFF
--- a/meta/makefile.pret
+++ b/meta/makefile.pret
@@ -8,9 +8,6 @@
 	:runtime-conflict       [ :on "MooseX::ClassAttribute <= 0.26"^^:CpanId ];
 	:runtime-requirement    [ :on "Role::Tiny 1.000000"^^:CpanId ];
 	:runtime-requirement    [ :on "Sub::Exporter::Progressive"^^:CpanId ];
-	:runtime-recommendation [ :on "MooseX::ClassAttribute 0.27"^^:CpanId ];
-	:develop-requirement    [ :on "Moose"^^:CpanId ];
-	:develop-requirement    [ :on "MooseX::ClassAttribute"^^:CpanId ];
 	:develop-requirement    [ :on "Sub::Exporter"^^:CpanId ];
 	:develop-recommendation [ :on "Dist::Inkt"^^:CpanId ];
 	.


### PR DESCRIPTION
Removed requirement/recommendations for Moose and MooseX::ClassAttribute so
that RPM packagers wouldn't try to bring them in.
