### PR TITLE
Hook into Moo::Role via role_application_steps rather than using an after modifier on apply_roles_to_package.

### DIFF
--- a/lib/MooX/CaptainHook.pm
+++ b/lib/MooX/CaptainHook.pm
@@ -50,24 +50,26 @@ use constant ON_APPLICATION => do {
 		$MooX::CaptainHook::OnApplication::VERSION   = '0.011';
 	}
 	use Moo::Role;
-	after apply_roles_to_package => sub
+	around role_application_steps => sub
 	{
-		my ($toolage, $package, @roles) = @_;
-		
-		for my $role (@roles)
-		{
-			'MooX::CaptainHook'->_fire(
-				$on_application{$role},
-				"OnApplication: $package $role",
-				[ $package, $role ],
-			);
-			
-			# This stuff is for internals...
-			push @{ $on_application{$package} ||= [] }, @{ $on_application{$role} || [] }
-				if MooX::CaptainHook::is_role($package);
-			push @{ $on_inflation{$package} ||= [] }, @{ $on_inflation{$role} || [] };
-		}
+		my ( $orig, $self, @args ) = @_;
+		$self->$orig( @args ), '_apply_captain_hook';
 	};
+
+	sub _apply_captain_hook {
+		my ( $toolage, $package, $role ) = @_;
+		'MooX::CaptainHook'->_fire(
+			$on_application{$role},
+			"OnApplication: $package $role",
+			[ $package, $role ],
+		);
+
+	# This stuff is for internals...
+		push @{ $on_application{$package} ||= [] }, @{ $on_application{$role} || [] }
+			if MooX::CaptainHook::is_role($package);
+		push @{ $on_inflation{$package} ||= [] }, @{ $on_inflation{$role} || [] };
+	}
+
 	__PACKAGE__;
 };
 

--- a/t/25hook_external.t
+++ b/t/25hook_external.t
@@ -1,0 +1,33 @@
+=head1 PURPOSE
+
+Test C<on_application> hook from L<MooX::CaptainHook>.
+
+=head1 AUTHOR
+
+Toby Inkster E<lt>tobyink@cpan.orgE<gt>.
+
+=head1 COPYRIGHT AND LICENCE
+
+This software is copyright (c) 2013 by Toby Inkster.
+
+This is free software; you can redistribute it and/or modify it under
+the same terms as the Perl 5 programming language system itself.
+
+=cut
+
+use strict;
+use warnings;
+use Test::More;
+
+use lib './t/lib';
+
+use Local::Class;
+is_deeply(
+	\@Local::Role::output,
+	[
+		"Local::Class Local::Role",
+	],
+);
+
+
+done_testing;

--- a/t/lib/Local/Class.pm
+++ b/t/lib/Local/Class.pm
@@ -1,0 +1,6 @@
+package Local::Class;
+
+use Moo;
+with 'Local::Role'; # "Local::Role applied to Local::Class"
+
+1;

--- a/t/lib/Local/Role.pm
+++ b/t/lib/Local/Role.pm
@@ -1,0 +1,11 @@
+package Local::Role;
+use Moo::Role;
+use MooX::CaptainHook qw(on_application);
+
+our @output;
+
+on_application {
+	push @output, "@{$_[0]}";
+};
+
+1;


### PR DESCRIPTION


Firing hooks after apply_roles_to_package is logical, but if a role is consumed via Moo::Role::with, the after modifier is put in place too late:

1. Moo::Role::with calls apply_roles_to_package
2. apply_roles_to_package loads the role package
3. the role package applies the after modifier to apply_roles_to_package

However, by by step 3, execution is already in the *unmodified* apply_roles_to_package, so the hook never gets fired.

Instead, this approach adds a final step to the Moo::Role's list of "role application steps".  The difference between this approach and the previous one is that (at least as of Role::Tiny 2.002004), the final registration of the role application (e.g. recording it in %Role::Tiny::APPLIED_TO) is done *after* the hook is fired.