### PR TITLE
long class names no longer cause "Identifier too long" error

### DIFF
--- a/t/40long_identifier.t
+++ b/t/40long_identifier.t
@@ -1,0 +1,27 @@
+use Test::More;
+
+package
+Quite::Very::Very::Very::Very::Very::Very::Very::Very::Very::Very::Very::Very::Very::Very::Very::Very::Very::Very::Very::Very::Very::Very::Very::Very::Very::Very::Very::Very::Very::Very::Very::Very::Very::Very::Very::Very::Very::Very::Long::Name
+{
+    use Moo::Role;
+    use MooX::ClassAttribute;
+    class_has file_attr_class => (
+        is       => 'ro',
+    );
+
+}
+
+package Short  {
+    use Moo;
+    use Test::More;
+
+    my @roles
+      = (qw(
+Quite::Very::Very::Very::Very::Very::Very::Very::Very::Very::Very::Very::Very::Very::Very::Very::Very::Very::Very::Very::Very::Very::Very::Very::Very::Very::Very::Very::Very::Very::Very::Very::Very::Very::Very::Very::Very::Very::Very::Long::Name
+      ));
+
+
+      ok( eval { Moo::Role->create_class_with_roles( __PACKAGE__, @roles ) }, 'create class' ) ;
+}
+
+done_testing;


### PR DESCRIPTION
Perl allows only so many characters in an identfier, and composition with Moo roles and classes can cause a package name's length to approach the legal limit.

Moo::Role ensures that the package name itself remains legal, but a fully qualified variable name may be too long.

To work around this, expressions involving a fully qualified variable name are rewritten into a 'do' block which enters the package, and then uses the relative variable name.  The actual implementation is a bit clumsy.

See https://rt.cpan.org/Ticket/Display.html?id=145070  and the t/40long_identifier.t test